### PR TITLE
Require version 0.8.2 or higher of the "dompdf" library

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -58,8 +58,7 @@ TCPDF support:
 
 wkhtmltopdf support:
 
-  1. Download wkhtmltopdf from
-  https://github.com/wkhtmltopdf/wkhtmltopdf/releases. You can choose to
+  1. Download wkhtmltopdf from https://wkhtmltopdf.org/. You can choose to
   download the source and compile it or simply download the static binary,
   which doesn't require you to compile anything. Note that the compiled
   version may require a running X server (static uses patched libs that can
@@ -67,7 +66,7 @@ wkhtmltopdf support:
   2. Place the wkhtmltopdf executable into one of the supported paths. 
   (usually sites/all/modules/print/lib).  You can also place a symbolic link
   to the executable.
-  3. Check https://github.com/wkhtmltopdf/wkhtmltopdf/ for further information.
+  3. Check https://wkhtmltopdf.org/ for further information.
 
 UPDATE
 ------

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -59,7 +59,7 @@ TCPDF support:
 wkhtmltopdf support:
 
   1. Download wkhtmltopdf from
-  http://code.google.com/p/wkhtmltopdf/downloads/list. You can choose to
+  https://github.com/wkhtmltopdf/wkhtmltopdf/releases. You can choose to
   download the source and compile it or simply download the static binary,
   which doesn't require you to compile anything. Note that the compiled
   version may require a running X server (static uses patched libs that can
@@ -67,7 +67,7 @@ wkhtmltopdf support:
   2. Place the wkhtmltopdf executable into one of the supported paths. 
   (usually sites/all/modules/print/lib).  You can also place a symbolic link
   to the executable.
-  3. Check http://code.google.com/p/wkhtmltopdf/ for further information.
+  3. Check https://github.com/wkhtmltopdf/wkhtmltopdf/ for further information.
 
 UPDATE
 ------

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -23,24 +23,24 @@ supported paths:
 
 dompdf support:
   The dompdf tool produces results that are more faithful to the HTML
-  printer-friendly page. Unicode is not supported (only ISO-8859-1).
-  This tool is not supported and there are several known bugs that result
-  from its incomplete implementation.
+  printer-friendly page. Good support of CSS 2.1 and partially CSS3.
 
-  1. Download dompdf from http://code.google.com/p/dompdf/downloads/list
+  The recommended version of this tool is 0.8.2 since it is fully compatible
+  with PHP 7.1, and security support has ended for all prior versions of PHP
+  as of December 31, 2018.
+
+  1. Download dompdf from https://github.com/dompdf/dompdf/releases. Make
+  sure to download the full release zipfile. If you download only a source
+  code file, you will also need to download and install the php-font-lib.
   2. Extract the contents of the downloaded package into one of the
   supported paths.
-  3. Check if dompdf_config.inc.php fits your installation. In 99% of cases,
-  no changes are necessary, so just try to use it and only edit anything if
-  the PDF generation fails.
-  4. Grant write access to the lib/fonts directory to your webserver user.
-  5. If you're using dompdf-0.5.1, delete the dompdf.php file as it contains
-  a security vulnerability
-  6. If you're using dompdf-0.6 or later, you can try to enable the Unicode
-  support, but you'll need to add some Unicode fonts. See 
-  http://groups.google.com/group/dompdf/browse_thread/thread/9f7bc0162b04d5cf
-  for further info on this.
-  7. Check http://code.google.com/p/dompdf/ for further information.
+  3. Grant write access to the lib/fonts directory for your webserver user.
+  4. Review the recommendations for securing your dompdf installation at
+  https://github.com/dompdf/dompdf/wiki/Securing-dompdf
+  5. If upgrading to 0.7 (or newer) from 0.6 (or older), visit the settings
+  page on your site at http://www.example.com/admin/settings/print/pdf
+  and select the new path for the "PDF generation tool" setting.
+  6. Check https://github.com/dompdf/dompdf/ for further information.
 
 TCPDF support:
   TCPDF seems to be more actively developed than dompdf, but it's support

--- a/print.pages.inc
+++ b/print.pages.inc
@@ -184,7 +184,7 @@ function _print_var_generator($node, $message = NULL, $cid = NULL) {
   $print['favicon'] = theme_get_setting('toggle_favicon') ? "<link rel='shortcut icon' href='". theme_get_setting('favicon') ."' type='image/x-icon' />\n" : '';
 
   if (!empty($print_css)) {
-    drupal_add_css(strtr($print_css, array('%t' => drupal_get_path('theme', variable_get('theme_default')))));
+    drupal_add_css(strtr($print_css, array('%t' => drupal_get_path('theme', variable_get('theme_default', '')))));
   }
   else {
     drupal_add_css(drupal_get_path('module', 'print') .'/css/print.css');

--- a/print_pdf/print_pdf.admin.inc
+++ b/print_pdf/print_pdf.admin.inc
@@ -185,7 +185,8 @@ function print_pdf_settings() {
       '#type' => 'checkbox',
       '#title' => t('Auto-configure the PDF tool settings'),
       '#default_value' => variable_get('print_pdf_autoconfig', PRINT_PDF_AUTOCONFIG_DEFAULT),
-      '#description' => t('If you disable this option, the pdf tool settings must be configured manually. For TCDPF, edit the tcpdf/config/tcpdf_config.php file. For dompdf, edit the dompdf/dompdf_config.inc.php file.'),
+      '#description' => t('If you disable this option, the pdf tool settings must be configured manually. For TCDPF, edit the tcpdf/config/tcpdf_config.php file. For dompdf 0.6.2 and lower, edit the dompdf/dompdf_config.inc.php file.')
+        . ' ' . t('For dompdf 0.7 and higher, this option has no effect.'),
     );
     $form['settings']['print_pdf_font_family'] = array(
       '#type' => 'textfield',
@@ -208,13 +209,14 @@ function print_pdf_settings() {
       '#type' => 'checkbox',
       '#title' => t('Enable font subsetting'),
       '#default_value' => variable_get('print_pdf_font_subsetting', PRINT_PDF_FONT_SUBSETTING_DEFAULT),
-      '#description' => t('(TCPDF only) Only embed those font characters that are actually used.  This can generates smaller PDF files but may significantly slow down processing.'),
+      '#description' => t('(TCPDF and dompdf only) Only embed those font characters that are actually used.  This can generates smaller PDF files but may significantly slow down processing.'),
     );
     $form['settings']['print_pdf_dompdf_unicode'] = array(
       '#type' => 'checkbox',
       '#title' => t("Use dompdf's Unicode Mode"),
       '#default_value' => variable_get('print_pdf_dompdf_unicode', PRINT_PDF_DOMPDF_UNICODE_DEFAULT),
-      '#description' => t("If enabled, dompdf's Unicode mode is used. If not, the module will attempt to convert some non-ASCII chars to ISO-8859-1."),
+      '#description' => t("If enabled, dompdf's Unicode mode is used. If not, the module will attempt to convert some non-ASCII chars to ISO-8859-1.")
+        . ' ' . t('For dompdf 0.7 and higher, this option is always turned on.'),
     );
     $form['settings']['print_pdf_wkhtmltopdf_options'] = array(
       '#type' => 'textfield',
@@ -282,14 +284,14 @@ function _print_pdf_settings_validate($form, &$form_state) {
  *   array of filenames with the include-able PHP file of the located tools
  */
 function _print_pdf_tools() {
-  $tools = array_keys(file_scan_directory(drupal_get_path('module', 'print'), '^dompdf_config.inc.php$'));
+  $tools = array_keys(file_scan_directory(drupal_get_path('module', 'print'), '^(dompdf_config.inc.php|Dompdf.php)$'));
   $tools = array_merge($tools, array_keys(file_scan_directory(drupal_get_path('module', 'print'), '^tcpdf.php$')));
   $tools = array_merge($tools, array_keys(file_scan_directory(drupal_get_path('module', 'print'), '^wkhtmltopdf')));
   $tools = array_merge($tools, array_keys(file_scan_directory(PRINT_PDF_LIB_PATH, '^dompdf_config.inc.php$')));
   $tools = array_merge($tools, array_keys(file_scan_directory(PRINT_PDF_LIB_PATH, '^tcpdf.php$')));
   $tools = array_merge($tools, array_keys(file_scan_directory(PRINT_PDF_LIB_PATH, '^wkhtmltopdf')));
   if (module_exists('libraries')) {
-    $tools = array_merge($tools, array_keys(file_scan_directory(libraries_get_path('dompdf'), '^dompdf_config.inc.php$')));
+    $tools = array_merge($tools, array_keys(file_scan_directory(libraries_get_path('dompdf'), '^(dompdf_config.inc.php|Dompdf.php)$')));
     $tools = array_merge($tools, array_keys(file_scan_directory(libraries_get_path('tcpdf'), '^tcpdf.php$')));
     $tools = array_merge($tools, array_keys(file_scan_directory(libraries_get_path('wkhtmltopdf'), '^wkhtmltopdf')));
   }

--- a/print_pdf/print_pdf.admin.inc
+++ b/print_pdf/print_pdf.admin.inc
@@ -186,7 +186,7 @@ function print_pdf_settings() {
       '#title' => t('Auto-configure the PDF tool settings'),
       '#default_value' => variable_get('print_pdf_autoconfig', PRINT_PDF_AUTOCONFIG_DEFAULT),
       '#description' => t('If you disable this option, the pdf tool settings must be configured manually. For TCDPF, edit the tcpdf/config/tcpdf_config.php file. For dompdf 0.6.2 and lower, edit the dompdf/dompdf_config.inc.php file.')
-        . ' ' . t('For dompdf 0.7 and higher, this option has no effect.'),
+        . ' ' . t('Dompdf 0.7 and higher does not rely on a config file.'),
     );
     $form['settings']['print_pdf_font_family'] = array(
       '#type' => 'textfield',

--- a/print_pdf/print_pdf.module
+++ b/print_pdf/print_pdf.module
@@ -91,6 +91,9 @@ function print_pdf_init() {
     if (basename($print_pdf_pdf_tool) == 'dompdf_config.inc.php') {
       $pdf_dirs[] = PRINT_PDF_DOMPDF_CACHE_DIR_DEFAULT . '/fonts';
     }
+    else if (basename($print_pdf_pdf_tool) == 'Dompdf.php') {
+      $pdf_dirs[] = PRINT_PDF_DOMPDF_CACHE_DIR_DEFAULT . '/fonts';
+    }
     elseif (basename($print_pdf_pdf_tool) == 'tcpdf.php') {
       foreach (array('cache', 'images') as $dir) {
         $pdf_dirs[] = PRINT_PDF_TCPDF_CACHE_DIR_DEFAULT . '/' . $dir;
@@ -218,7 +221,25 @@ function print_pdf_requirements($phase) {
             'severity' => REQUIREMENT_ERROR,
           );
         }
-        elseif (basename($print_pdf_pdf_tool) == 'dompdf_config.inc.php') {
+        elseif (basename($print_pdf_pdf_tool) == 'dompdf_config.inc.php' || basename($print_pdf_pdf_tool) == 'Dompdf.php') {
+          $version = _print_pdf_dompdf_version();
+          $min_version = '0.8.2';
+
+          if (version_compare($version, $min_version, '<')) {
+            $requirements['print_pdf_tool'] = array(
+              'title' => $t('Printer, email and PDF versions - PDF generation library'),
+              'value' => $t('Unsupported Dompdf version'),
+              'description' => $t('The currently selected version of Dompdf (@version) is not supported. Please update to !url.', array('@version' => $version, '!url' => l($t('version @min or higher', array('@min' => $min_version)), 'https://github.com/dompdf/dompdf/releases'))),
+              'severity' => REQUIREMENT_ERROR,
+            );
+          }
+          else {
+            $requirements['print_pdf_tool'] = array(
+              'title' => $t('Printer, email and PDF versions - PDF generation library'),
+              'value' => $t('Dompdf') . ' ' . $version,
+            );
+          }
+
           if (variable_get('print_pdf_autoconfig', PRINT_PDF_AUTOCONFIG_DEFAULT)) {
             $directory = file_directory_path() . '/' . PRINT_PDF_DOMPDF_CACHE_DIR_DEFAULT . '/fonts';
             if (!is_dir($directory) || !is_writable($directory)) {
@@ -635,6 +656,56 @@ function print_pdf_link_allowed($args) {
     return _print_page_match($print_pdf_sys_link_visibility, $_GET['q'], $print_pdf_sys_link_pages);
   }
   return FALSE;
+}
+
+/**
+ * Find out the version of the dompdf library
+ */
+function _print_pdf_dompdf_version() {
+  $print_pdf_pdf_tool = variable_get('print_pdf_pdf_tool', PRINT_PDF_PDF_TOOL_DEFAULT);
+  if (file_exists($print_pdf_pdf_tool)) {
+    include_once($print_pdf_pdf_tool);
+  }
+
+  if (basename($print_pdf_pdf_tool) == 'Dompdf.php') {
+    $dompdf_base = dirname(dirname($print_pdf_pdf_tool));
+    $version_file = $dompdf_base . '/VERSION';
+    if (file_exists($version_file)) {
+      // From 0.7.0 beta 3 onwards, there's a VERSION file.
+      return file_get_contents($version_file);
+    }
+    elseif (basename(dirname($print_pdf_pdf_tool)) === 'src') {
+      // The dompdf tool started using PSR-4 in 0.7.0 beta 2.
+      return '0.7.0 beta 2';
+    }
+    elseif (basename(dirname($print_pdf_pdf_tool)) === 'Dompdf') {
+      // In 0.7.0 beta 1, it was src/Dompdf/Dompdf.php.
+      return '0.7.0 beta 1';
+    }
+  }
+  else {
+    // Poor man's way to find dompdf version pre 0.7.
+    if (defined('DOMPDF_ENABLE_AUTOLOAD')) {
+      // It is not possible to tell apart 0.6.0, 0.6.1 or 0.6.2.
+      return '0.6.0, or higher';
+    }
+    elseif (defined('DOMPDF_ADMIN_USERNAME')) {
+      return '0.6.0 beta3';
+    }
+    elseif (defined('DOMPDF_LOG_OUTPUT_FILE')) {
+      return '0.6.0 beta2';
+    }
+    elseif (defined('DOMPDF_FONT_CACHE')) {
+      return '0.6.0 beta1';
+    }
+    elseif (defined('DOMPDF_CHROOT')) {
+      return '0.5.2';
+    }
+    elseif (defined('DOMPDF_DIR')) {
+      return '0.5.1';
+    }
+  }
+  return 'unknown';
 }
 
 /**

--- a/print_pdf/print_pdf.pages.inc
+++ b/print_pdf/print_pdf.pages.inc
@@ -192,9 +192,9 @@ function _print_pdf_dompdf($print, $html, $filename = NULL) {
   $unicode = variable_get('print_pdf_dompdf_unicode', PRINT_PDF_DOMPDF_UNICODE_DEFAULT);
   $font_subsetting = variable_get('print_pdf_dompdf_font_subsetting', PRINT_PDF_DOMPDF_FONT_SUBSETTING_DEFAULT);
   $font_cache = file_directory_path() . '/' . PRINT_PDF_DOMPDF_CACHE_DIR_DEFAULT . '/fonts/';
-
-  if (basename($print_pdf_pdf_tool) == 'dompdf_config.inc.php') {
-    // Version of dompdf is < 0.7.
+  
+  if (version_compare($version, '0.7', '<')) {
+    // Version of dompdf is 0.6.* or 0.5.*.
     if (variable_get('print_pdf_autoconfig', PRINT_PDF_AUTOCONFIG_DEFAULT)) {
       if (!defined('DOMPDF_ENABLE_PHP')) define("DOMPDF_ENABLE_PHP", FALSE);
       if (!defined('DOMPDF_ENABLE_REMOTE')) define("DOMPDF_ENABLE_REMOTE", TRUE);
@@ -234,11 +234,11 @@ function _print_pdf_dompdf($print, $html, $filename = NULL) {
     $dompdf->set_option('font_cache', $font_cache);
   }
 
-  // Try to use local file access for image files
-  $html = _print_pdf_file_access_images($html);
-
   // Remove all scripts due to security concerns.
   $html = preg_replace('!<script(.*?)>(.*?)</script>!is', '', $html);
+
+  // Try to use local file access for image files
+  $html = _print_pdf_file_access_images($html);
 
   // Spaces in img URLs must be replaced with %20
   $pattern = '!<(img\s[^>]*?)>!is';

--- a/print_pdf/print_pdf.pages.inc
+++ b/print_pdf/print_pdf.pages.inc
@@ -116,6 +116,9 @@ function print_pdf_generate_html($print, $html, $filename = NULL) {
   if (basename($print_pdf_pdf_tool) == 'dompdf_config.inc.php') {
     return _print_pdf_dompdf($print, $html, $filename);
   }
+  else if (basename($print_pdf_pdf_tool) == 'Dompdf.php') {
+    return _print_pdf_dompdf($print, $html, $filename);
+  }
   elseif (basename($print_pdf_pdf_tool) == 'tcpdf.php') {
     return _print_pdf_tcpdf($print, $html, $filename);
   }
@@ -181,26 +184,61 @@ function _print_pdf_file_access_images($html) {
  * @see print_pdf_controller()
  */
 function _print_pdf_dompdf($print, $html, $filename = NULL) {
+  $version = _print_pdf_dompdf_version();
   $print_pdf_pdf_tool = variable_get('print_pdf_pdf_tool', PRINT_PDF_PDF_TOOL_DEFAULT);
   $print_pdf_paper_size = variable_get('print_pdf_paper_size', PRINT_PDF_PAPER_SIZE_DEFAULT);
   $print_pdf_page_orientation = variable_get('print_pdf_page_orientation', PRINT_PDF_PAGE_ORIENTATION_DEFAULT);
   $print_pdf_content_disposition = variable_get('print_pdf_content_disposition', PRINT_PDF_CONTENT_DISPOSITION_DEFAULT);
+  $unicode = variable_get('print_pdf_dompdf_unicode', PRINT_PDF_DOMPDF_UNICODE_DEFAULT);
+  $font_subsetting = variable_get('print_pdf_dompdf_font_subsetting', PRINT_PDF_DOMPDF_FONT_SUBSETTING_DEFAULT);
+  $font_cache = file_directory_path() . '/' . PRINT_PDF_DOMPDF_CACHE_DIR_DEFAULT . '/fonts/';
 
-  if (variable_get('print_pdf_autoconfig', PRINT_PDF_AUTOCONFIG_DEFAULT)) {
-    if (!defined('DOMPDF_ENABLE_PHP')) define("DOMPDF_ENABLE_PHP", FALSE);
-    if (!defined('DOMPDF_ENABLE_REMOTE')) define("DOMPDF_ENABLE_REMOTE", TRUE);
-    if (!defined('DOMPDF_TEMP_DIR')) define("DOMPDF_TEMP_DIR", file_directory_temp());
-    if (!defined('DOMPDF_UNICODE_ENABLED')) define("DOMPDF_UNICODE_ENABLED", variable_get('print_pdf_dompdf_unicode', PRINT_PDF_DOMPDF_UNICODE_DEFAULT));
-    if (!defined('DOMPDF_FONT_CACHE')) define("DOMPDF_FONT_CACHE", file_directory_path() . '/' . PRINT_PDF_DOMPDF_CACHE_DIR_DEFAULT . '/fonts/');
+  if (basename($print_pdf_pdf_tool) == 'dompdf_config.inc.php') {
+    // Version of dompdf is < 0.7.
+    if (variable_get('print_pdf_autoconfig', PRINT_PDF_AUTOCONFIG_DEFAULT)) {
+      if (!defined('DOMPDF_ENABLE_PHP')) define("DOMPDF_ENABLE_PHP", FALSE);
+      if (!defined('DOMPDF_ENABLE_REMOTE')) define("DOMPDF_ENABLE_REMOTE", TRUE);
+      if (!defined('DOMPDF_TEMP_DIR')) define("DOMPDF_TEMP_DIR", file_directory_temp());
+      if (!defined('DOMPDF_UNICODE_ENABLED')) define("DOMPDF_UNICODE_ENABLED", $unicode);
+      if (!defined('DOMPDF_ENABLE_FONTSUBSETTING')) define("DOMPDF_ENABLE_FONTSUBSETTING", $font_subsetting);
+      if (!defined('DOMPDF_FONT_CACHE')) define("DOMPDF_FONT_CACHE", $font_cache);
+    }
+
+    require_once($print_pdf_pdf_tool);
+    if (function_exists('spl_autoload_register')) {
+      spl_autoload_register('DOMPDF_autoload');
+      // Earlier dompdf versions could generate xml errors. Tell libxml to
+      // hide them.
+      libxml_use_internal_errors(TRUE);
+      $dompdf = new DOMPDF();
+    }
   }
+  else {
+    // Version of dompdf is >= 0.7.
+    $tool_path = dirname($print_pdf_pdf_tool) . '/../autoload.inc.php';
+    if (file_exists($tool_path)) {
+      require_once $tool_path;
+    }
+    else {
+      watchdog('print_pdf', 'Configured PDF tool does not exist at path: %path', array('%path' => $tool_path), WATCHDOG_ERROR);
+      throw new Exception("Configured PDF tool does not exist, unable to generate PDF.");
+    }
 
-  require_once($print_pdf_pdf_tool);
-  if (function_exists('spl_autoload_register')) {
-    spl_autoload_register('DOMPDF_autoload');
+    $dompdf = new \Dompdf\Dompdf();
+    $unicode = TRUE;
+
+    $dompdf->set_option('enable_php', FALSE);
+    $dompdf->set_option('enable_remote', TRUE);
+    $dompdf->set_option('temp_dir', file_directory_temp());
+    $dompdf->set_option('enable_font_subsetting', $font_subsetting);
+    $dompdf->set_option('font_cache', $font_cache);
   }
 
   // Try to use local file access for image files
   $html = _print_pdf_file_access_images($html);
+
+  // Remove all scripts due to security concerns.
+  $html = preg_replace('!<script(.*?)>(.*?)</script>!is', '', $html);
 
   // Spaces in img URLs must be replaced with %20
   $pattern = '!<(img\s[^>]*?)>!is';
@@ -215,7 +253,6 @@ function _print_pdf_dompdf($print, $html, $filename = NULL) {
   $host = $url_array['host'];
   $path = dirname($url_array['path']) .'/';
 
-  $dompdf = new DOMPDF();
   $dompdf->set_base_path($path);
   $dompdf->set_host($host);
   $dompdf->set_paper(drupal_strtolower($print_pdf_paper_size), $print_pdf_page_orientation);
@@ -225,25 +262,25 @@ function _print_pdf_dompdf($print, $html, $filename = NULL) {
 //  $html = theme('print_pdf_dompdf_footer', $html);
 
   // If dompdf Unicode support is disabled, try to convert to ISO-8859-1 and then to HTML entities
-  if (!variable_get('print_pdf_dompdf_unicode', PRINT_PDF_DOMPDF_UNICODE_DEFAULT)) {
-  // Convert the euro sign to an HTML entity
-  $html = str_replace('€', '&#0128;', $html);
+  if (!$unicode) {
+    // Convert the euro sign to an HTML entity
+    $html = str_replace('€', '&#0128;', $html);
 
-  // Convert from UTF-8 to ISO 8859-1 and then to HTML entities
-  if (function_exists('utf8_decode')) {
-    $html = utf8_decode($html);
-  }
-// iconv fails silently when it encounters something that it doesn't know, so don't use it
-//  else if (function_exists('iconv')) {
-//    $html = iconv('UTF-8', 'ISO-8859-1', $html);
-//  }
-  elseif (function_exists('mb_convert_encoding')) {
-    $html = mb_convert_encoding($html, 'ISO-8859-1', 'UTF-8');
-  }
-  elseif (function_exists('recode_string')) {
-    $html = recode_string('UTF-8..ISO_8859-1', $html);
-  }
-  $html = htmlspecialchars_decode(htmlentities($html, ENT_NOQUOTES, 'ISO-8859-1'), ENT_NOQUOTES);
+    // Convert from UTF-8 to ISO 8859-1 and then to HTML entities
+    if (function_exists('utf8_decode')) {
+      $html = utf8_decode($html);
+    }
+  // iconv fails silently when it encounters something that it doesn't know, so don't use it
+  //  else if (function_exists('iconv')) {
+  //    $html = iconv('UTF-8', 'ISO-8859-1', $html);
+  //  }
+    elseif (function_exists('mb_convert_encoding')) {
+      $html = mb_convert_encoding($html, 'ISO-8859-1', 'UTF-8');
+    }
+    elseif (function_exists('recode_string')) {
+      $html = recode_string('UTF-8..ISO_8859-1', $html);
+    }
+    $html = htmlspecialchars_decode(htmlentities($html, ENT_NOQUOTES, 'ISO-8859-1'), ENT_NOQUOTES);
   }
   else {
     // Otherwise, ensure the content is properly formatted Unicode.


### PR DESCRIPTION
The `dompdf` library is the most recommended addon library for the `print_pdf` submodule. Given the fact that PHP 7.0 and lower is reaching end of life on December 31, 2018 or earlier, this patch will dramatically improve security for many users.

**Changes in this update**
- Port code from print module 7.x-2.2 to support upgrading dompdf to 0.7.0+.
- Require dompdf 0.8.2 or higher which is compatible with PHP 7.1+.
- Update INSTALL.txt to simplify installation, remove notes about 0.6 and lower, new github.com URLs, a link to securing your release, and upgrade instructions.
- Change admin settings page -- Auto-config option no longer applies to dompdf 0.7+. Font subsetting applies to dompdf. Unicode mode is always on in dompdf 0.7+.
- Add version check in hook_requirements().
- Fix warning about missing an argument when calling variable_get() in print.pages.inc.
- Update URLs for the wkhtmltopdf library.